### PR TITLE
Add Remotes to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,9 @@ Suggests:
     profvis,
     testthat (>= 3.0.0),
     tibble
+Remotes:
+    github::richelbilderbeek/ormr
+    github::richelbilderbeek/plinkr
 URL: https://github.com/richelbilderbeek/gcaer/
 BugReports: https://github.com/richelbilderbeek/gcaer/
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Suggests:
     testthat (>= 3.0.0),
     tibble
 Remotes:
-    github::richelbilderbeek/ormr
+    github::richelbilderbeek/ormr,
     github::richelbilderbeek/plinkr
 URL: https://github.com/richelbilderbeek/gcaer/
 BugReports: https://github.com/richelbilderbeek/gcaer/


### PR DESCRIPTION
ormr and plinkr aren't on CRAN or Bioc, so need to specify github repo where they can be found.